### PR TITLE
chore: fix DevContainer JDK version and add VS Code tasks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
   "name": "MCP Kotlin Starter",
-  "image": "mcr.microsoft.com/devcontainers/java:1-21",
+  "image": "mcr.microsoft.com/devcontainers/java:1-17",
   "features": {},
-  "postCreateCommand": "./gradlew shadowJar",
+  "postCreateCommand": "./gradlew fatJar",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": "./gradlew fatJar",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run (stdio)",
+      "type": "shell",
+      "command": "./gradlew runStdio",
+      "group": "test"
+    },
+    {
+      "label": "Run (HTTP)",
+      "type": "shell",
+      "command": "./gradlew runHttp",
+      "group": "test"
+    },
+    {
+      "label": "Watch (continuous build)",
+      "type": "shell",
+      "command": "./gradlew fatJar --continuous",
+      "group": "build",
+      "isBackground": true
+    }
+  ]
+}


### PR DESCRIPTION
Uses JDK 17 (matches jvmToolchain), fixes fatJar task name, adds Build/Run/Watch tasks.